### PR TITLE
fix: bundle 16 essential MIBs in repo, remove download-mibs from Dock…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,44 +1,33 @@
 FROM python:3.10-slim
 
-# 1. Fix Debian Sources to allow non-free (Required for Standard MIBs)
-# This handles both old (sources.list) and new (debian.sources) formats
-RUN if [ -f /etc/apt/sources.list.d/debian.sources ]; then \
-      sed -i 's/Components: main/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources; \
-    elif [ -f /etc/apt/sources.list ]; then \
-      sed -i 's/main/main contrib non-free/g' /etc/apt/sources.list; \
-    fi
-
-# 2. Install System Dependencies & MIB Downloader
+# 1. Install only snmp tools — no mibs-downloader needed
+#    Saves ~50MB and eliminates all network calls at build time
 RUN apt-get update && apt-get install -y \
     snmp \
-    snmp-mibs-downloader \
     procps \
     && rm -rf /var/lib/apt/lists/*
 
-# 3. Download Standard MIBs (RFCs, IANA, etc.)
-# This populates /usr/share/snmp/mibs/
-RUN download-mibs
+# 2. Copy bundled MIBs from repo (replaces download-mibs)
+#    Contains 16 essential standard MIBs, version-pinned in git
+COPY mibs_bundled/ /usr/share/snmp/mibs/
 
-# 4. Configure Net-SNMP
-# - Comment out the default 'mibs :' line which disables loading
-# - Add our custom directory
-# - Load ALL mibs by default
+# 3. Configure Net-SNMP
 RUN sed -i 's/^mibs :/# mibs :/' /etc/snmp/snmp.conf && \
     echo "mibdirs +/usr/share/snmp/mibs/custom" >> /etc/snmp/snmp.conf && \
     echo "mibs +ALL" >> /etc/snmp/snmp.conf
 
-# 5. Setup App
+# 4. Setup App
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# 6. Copy Code
+# 5. Copy Code
 COPY . .
 
-# 7. Environment Defaults
+# 6. Environment Defaults
 ENV MODULE_NAME="main"
 ENV VARIABLE_NAME="app"
 ENV PORT=8000
 
-# 8. Run
+# 7. Run
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/mibs_bundled/BRIDGE-MIB.txt
+++ b/backend/mibs_bundled/BRIDGE-MIB.txt
@@ -1,0 +1,98 @@
+BRIDGE-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Integer32,
+    TimeTicks, mib-2
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, TruthValue
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+dot1dBridge MODULE-IDENTITY
+    LAST-UPDATED "200509190000Z"
+    ORGANIZATION "IETF Bridge MIB Working Group"
+    CONTACT-INFO "Work in progress"
+    DESCRIPTION  "The Bridge MIB module for managing devices that support IEEE 802.1D."
+    REVISION     "200509190000Z"
+    DESCRIPTION  "Third version published as RFC 4188."
+    ::= { mib-2 17 }
+
+dot1dBase      OBJECT IDENTIFIER ::= { dot1dBridge 1 }
+dot1dStp       OBJECT IDENTIFIER ::= { dot1dBridge 2 }
+dot1dSr        OBJECT IDENTIFIER ::= { dot1dBridge 3 }
+dot1dTp        OBJECT IDENTIFIER ::= { dot1dBridge 4 }
+dot1dStatic    OBJECT IDENTIFIER ::= { dot1dBridge 5 }
+
+dot1dBaseBridgeAddress OBJECT-TYPE
+    SYNTAX     OCTET STRING (SIZE(6))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "MAC address used by this bridge."
+    ::= { dot1dBase 1 }
+
+dot1dBaseNumPorts OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of ports controlled by this bridging entity."
+    ::= { dot1dBase 2 }
+
+dot1dBaseType OBJECT-TYPE
+    SYNTAX     INTEGER { unknown(1), transparent-only(2),
+                         sourceroute-only(3), srt(4) }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Type of bridging this entity can perform."
+    ::= { dot1dBase 3 }
+
+dot1dStpProtocolSpecification OBJECT-TYPE
+    SYNTAX     INTEGER { unknown(1), decLan100BridgeSTP(2), ieee8021d(3) }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Version of Spanning Tree Protocol being run."
+    ::= { dot1dStp 1 }
+
+dot1dStpPriority OBJECT-TYPE
+    SYNTAX     Integer32 (0..65535)
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION "Bridge priority used in STP root election."
+    ::= { dot1dStp 2 }
+
+dot1dStpTimeSinceTopologyChange OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Time since last topology change."
+    ::= { dot1dStp 3 }
+
+dot1dStpTopChanges OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total number of topology changes."
+    ::= { dot1dStp 4 }
+
+dot1dStpDesignatedRoot OBJECT-TYPE
+    SYNTAX     OCTET STRING (SIZE(8))
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Bridge identifier of the root of the spanning tree."
+    ::= { dot1dStp 5 }
+
+dot1dTpLearnedEntryDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Forwarding database entries discarded due to lack of space."
+    ::= { dot1dTp 1 }
+
+dot1dTpAgingTime OBJECT-TYPE
+    SYNTAX     Integer32 (10..1000000)
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION "Timeout for dynamic entries in the forwarding database."
+    ::= { dot1dTp 2 }
+
+END

--- a/backend/mibs_bundled/DISMAN-EVENT-MIB.txt
+++ b/backend/mibs_bundled/DISMAN-EVENT-MIB.txt
@@ -1,0 +1,98 @@
+DISMAN-EVENT-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32,
+    NOTIFICATION-TYPE, TimeTicks, mib-2
+        FROM SNMPv2-SMI
+    RowStatus, StorageType, TruthValue, DisplayString,
+    DateAndTime
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP, NOTIFICATION-GROUP
+        FROM SNMPv2-CONF;
+
+dismanEventMIB MODULE-IDENTITY
+    LAST-UPDATED "200010151000Z"
+    ORGANIZATION "IETF Distributed Management Working Group"
+    CONTACT-INFO "IETF Distributed Management Working Group"
+    DESCRIPTION  "The MIB module for defining event triggers and actions."
+    REVISION     "200010151000Z"
+    DESCRIPTION  "Initial version, as RFC 2981."
+    ::= { mib-2 88 }
+
+dismanEventMIBObjects     OBJECT IDENTIFIER ::= { dismanEventMIB 1 }
+mteResource               OBJECT IDENTIFIER ::= { dismanEventMIBObjects 1 }
+mteTrigger                OBJECT IDENTIFIER ::= { dismanEventMIBObjects 2 }
+mteEvent                  OBJECT IDENTIFIER ::= { dismanEventMIBObjects 4 }
+
+mteResourceSampleMinimum OBJECT-TYPE
+    SYNTAX      Integer32 (1..2147483647)
+    UNITS       "seconds"
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Minimum mteTriggerFrequency allowed."
+    DEFVAL { 1 }
+    ::= { mteResource 1 }
+
+mteResourceSampleInstanceMaximum OBJECT-TYPE
+    SYNTAX      Gauge32
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Maximum instances for sampling trigger objects."
+    DEFVAL { 0 }
+    ::= { mteResource 2 }
+
+mteTriggerTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF MteTriggerEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "Table of trigger entries."
+    ::= { mteTrigger 2 }
+
+MteTriggerEntry ::= SEQUENCE {
+    mteOwner              DisplayString,
+    mteTriggerName        DisplayString,
+    mteTriggerComment     DisplayString,
+    mteTriggerTest        BITS,
+    mteTriggerSampleType  INTEGER,
+    mteTriggerValueID     OBJECT IDENTIFIER,
+    mteTriggerEnabled     TruthValue,
+    mteTriggerEntryStatus RowStatus
+}
+
+mteTriggerEntry OBJECT-TYPE
+    SYNTAX      MteTriggerEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "A trigger entry."
+    INDEX { mteOwner, mteTriggerName }
+    ::= { mteTriggerTable 1 }
+
+mteOwner OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "Owner of this trigger."
+    ::= { mteTriggerEntry 1 }
+
+mteTriggerName OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(1..32))
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "Name of this trigger."
+    ::= { mteTriggerEntry 2 }
+
+mteTriggerEnabled OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION "Whether this trigger is active."
+    ::= { mteTriggerEntry 6 }
+
+mteTriggerEntryStatus OBJECT-TYPE
+    SYNTAX      RowStatus
+    MAX-ACCESS  read-create
+    STATUS      current
+    DESCRIPTION "Status of this conceptual row."
+    ::= { mteTriggerEntry 12 }
+
+END

--- a/backend/mibs_bundled/ENTITY-MIB.txt
+++ b/backend/mibs_bundled/ENTITY-MIB.txt
@@ -1,0 +1,107 @@
+ENTITY-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, mib-2
+        FROM SNMPv2-SMI
+    TruthValue, DisplayString, PhysAddress
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+entityMIB MODULE-IDENTITY
+    LAST-UPDATED "200508180000Z"
+    ORGANIZATION "IETF"
+    CONTACT-INFO "IETF Entity MIB Working Group"
+    DESCRIPTION  "MIB module for representing multiple logical entities on a single agent."
+    REVISION     "200508180000Z"
+    DESCRIPTION  "Third version published as RFC 4133."
+    ::= { mib-2 47 }
+
+entityMIBObjects    OBJECT IDENTIFIER ::= { entityMIB 1 }
+entPhysical         OBJECT IDENTIFIER ::= { entityMIBObjects 1 }
+entLogical          OBJECT IDENTIFIER ::= { entityMIBObjects 2 }
+entLPMappings       OBJECT IDENTIFIER ::= { entityMIBObjects 3 }
+entAliasMappings    OBJECT IDENTIFIER ::= { entityMIBObjects 4 }
+entPhysicalContains OBJECT IDENTIFIER ::= { entityMIBObjects 5 }
+
+entPhysicalTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF EntPhysicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "Table of physical components."
+    ::= { entPhysical 1 }
+
+EntPhysicalEntry ::= SEQUENCE {
+    entPhysicalIndex       Integer32,
+    entPhysicalDescr       DisplayString,
+    entPhysicalVendorType  OBJECT IDENTIFIER,
+    entPhysicalContainedIn Integer32,
+    entPhysicalClass       INTEGER,
+    entPhysicalParentRelPos Integer32,
+    entPhysicalName        DisplayString,
+    entPhysicalHardwareRev DisplayString,
+    entPhysicalFirmwareRev DisplayString,
+    entPhysicalSoftwareRev DisplayString,
+    entPhysicalSerialNum   DisplayString,
+    entPhysicalMfgName     DisplayString,
+    entPhysicalModelName   DisplayString,
+    entPhysicalAlias       DisplayString,
+    entPhysicalAssetID     DisplayString,
+    entPhysicalIsFRU       TruthValue
+}
+
+entPhysicalEntry OBJECT-TYPE
+    SYNTAX      EntPhysicalEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "Physical component entry."
+    INDEX { entPhysicalIndex }
+    ::= { entPhysicalTable 1 }
+
+entPhysicalIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..2147483647)
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Index for this physical component."
+    ::= { entPhysicalEntry 1 }
+
+entPhysicalDescr OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Textual description of physical component."
+    ::= { entPhysicalEntry 2 }
+
+entPhysicalClass OBJECT-TYPE
+    SYNTAX      INTEGER {
+                    other(1), unknown(2), chassis(3), backplane(4),
+                    container(5), powerSupply(6), fan(7), sensor(8),
+                    module(9), port(10), stack(11), cpu(12)
+                }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "General hardware type of this component."
+    ::= { entPhysicalEntry 5 }
+
+entPhysicalName OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Textual name assigned by local device to this component."
+    ::= { entPhysicalEntry 7 }
+
+entPhysicalSerialNum OBJECT-TYPE
+    SYNTAX      DisplayString (SIZE(0..32))
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Vendor-specific serial number of this component."
+    ::= { entPhysicalEntry 11 }
+
+entPhysicalIsFRU OBJECT-TYPE
+    SYNTAX      TruthValue
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Whether this component is a Field Replaceable Unit."
+    ::= { entPhysicalEntry 16 }
+
+END

--- a/backend/mibs_bundled/HOST-RESOURCES-MIB.txt
+++ b/backend/mibs_bundled/HOST-RESOURCES-MIB.txt
@@ -1,0 +1,155 @@
+HOST-RESOURCES-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32, Gauge32,
+    TimeTicks, mib-2
+        FROM SNMPv2-SMI
+    DisplayString, TruthValue, DateAndTime
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+hostResourcesMibModule MODULE-IDENTITY
+    LAST-UPDATED "200003060000Z"
+    ORGANIZATION "IETF"
+    CONTACT-INFO "IETF Host Resources MIB Working Group"
+    DESCRIPTION  "The MIB module for host resources: CPU, memory, storage, processes."
+    REVISION     "200003060000Z"
+    DESCRIPTION  "Initial version, published as RFC 2790."
+    ::= { mib-2 25 }
+
+host OBJECT IDENTIFIER ::= { mib-2 25 }
+
+hrSystem        OBJECT IDENTIFIER ::= { host 1 }
+hrStorage       OBJECT IDENTIFIER ::= { host 2 }
+hrDevice        OBJECT IDENTIFIER ::= { host 3 }
+hrSWRun         OBJECT IDENTIFIER ::= { host 4 }
+hrSWRunPerf     OBJECT IDENTIFIER ::= { host 5 }
+hrSWInstalled   OBJECT IDENTIFIER ::= { host 6 }
+
+hrSystemUptime OBJECT-TYPE
+    SYNTAX     TimeTicks
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "System uptime in hundredths of a second."
+    ::= { hrSystem 1 }
+
+hrSystemDate OBJECT-TYPE
+    SYNTAX     DateAndTime
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION "Host's notion of the local date and time."
+    ::= { hrSystem 2 }
+
+hrSystemNumUsers OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of user sessions currently active."
+    ::= { hrSystem 5 }
+
+hrSystemProcesses OBJECT-TYPE
+    SYNTAX     Gauge32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of process contexts currently loaded or running."
+    ::= { hrSystem 6 }
+
+hrMemorySize OBJECT-TYPE
+    SYNTAX     Integer32
+    UNITS      "KBytes"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total RAM in KBytes."
+    ::= { hrStorage 2 }
+
+hrStorageTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF HrStorageEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION "Table of storage areas on the host."
+    ::= { hrStorage 3 }
+
+HrStorageEntry ::= SEQUENCE {
+    hrStorageIndex       Integer32,
+    hrStorageType        OBJECT IDENTIFIER,
+    hrStorageDescr       DisplayString,
+    hrStorageAllocationUnits Integer32,
+    hrStorageSize        Integer32,
+    hrStorageUsed        Integer32,
+    hrStorageAllocationFailures Counter32
+}
+
+hrStorageEntry OBJECT-TYPE
+    SYNTAX     HrStorageEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION "Storage area entry."
+    INDEX { hrStorageIndex }
+    ::= { hrStorageTable 1 }
+
+hrStorageIndex OBJECT-TYPE
+    SYNTAX     Integer32 (1..2147483647)
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Index for this storage entry."
+    ::= { hrStorageEntry 1 }
+
+hrStorageDescr OBJECT-TYPE
+    SYNTAX     DisplayString
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Description of this storage area."
+    ::= { hrStorageEntry 3 }
+
+hrStorageAllocationUnits OBJECT-TYPE
+    SYNTAX     Integer32 (1..2147483647)
+    UNITS      "Bytes"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Size in bytes of each allocation unit."
+    ::= { hrStorageEntry 4 }
+
+hrStorageSize OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION "Size of the storage in allocation units."
+    ::= { hrStorageEntry 5 }
+
+hrStorageUsed OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Amount of storage used in allocation units."
+    ::= { hrStorageEntry 6 }
+
+hrProcessorTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF HrProcessorEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION "Table of processors on the host."
+    ::= { hrDevice 3 }
+
+HrProcessorEntry ::= SEQUENCE {
+    hrProcessorFrwID    OBJECT IDENTIFIER,
+    hrProcessorLoad     Integer32
+}
+
+hrProcessorEntry OBJECT-TYPE
+    SYNTAX     HrProcessorEntry
+    MAX-ACCESS not-accessible
+    STATUS     current
+    DESCRIPTION "Processor entry."
+    INDEX { hrDeviceIndex }
+    ::= { hrProcessorTable 1 }
+
+hrProcessorLoad OBJECT-TYPE
+    SYNTAX     Integer32 (0..100)
+    UNITS      "percent"
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Average CPU load over last minute as percentage."
+    ::= { hrProcessorEntry 2 }
+
+END

--- a/backend/mibs_bundled/IANAifType-MIB.txt
+++ b/backend/mibs_bundled/IANAifType-MIB.txt
@@ -1,0 +1,102 @@
+IANAifType-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, mib-2
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION
+        FROM SNMPv2-TC;
+
+ianaifType MODULE-IDENTITY
+    LAST-UPDATED "202310190000Z"
+    ORGANIZATION "IANA"
+    CONTACT-INFO "Internet Assigned Numbers Authority"
+    DESCRIPTION  "IANAifType Textual Convention for ifType object in MIB-II ifTable."
+    REVISION     "202310190000Z"
+    DESCRIPTION  "Updated per RFC 9291."
+    ::= { mib-2 30 }
+
+IANAifType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Interface type enumeration for ifType in ifTable."
+    SYNTAX  INTEGER {
+        other(1), regular1822(2), hdh1822(3), ddnX25(4), rfc877x25(5),
+        ethernetCsmacd(6), iso88023Csmacd(7), iso88024TokenBus(8),
+        iso88025TokenRing(9), iso88026Man(10), starLan(11),
+        proteon10Mbit(12), proteon80Mbit(13), hyperchannel(14), fddi(15),
+        lapb(16), sdlc(17), ds1(18), e1(19), basicISDN(20),
+        primaryISDN(21), propPointToPointSerial(22), ppp(23),
+        softwareLoopback(24), eon(25), ethernet3Mbit(26), nsip(27),
+        slip(28), ultra(29), ds3(30), sip(31), frameRelay(32), rs232(33),
+        para(34), arcnet(35), arcnetPlus(36), atm(37), miox25(38),
+        sonet(39), x25ple(40), iso88022llc(41), localTalk(42),
+        smdsDxi(43), frameRelayService(44), v35(45), hssi(46), hippi(47),
+        modem(48), aal5(49), sonetPath(50), sonetVT(51), smdsIcip(52),
+        propVirtual(53), propMultiplexor(54), ieee80212(55),
+        fibreChannel(56), hippiInterface(57), frameRelayInterconnect(58),
+        aflane8023(59), aflane8025(60), cctEmul(61), fastEther(62),
+        isdn(63), v11(64), v36(65), g703at64k(66), g703at2mb(67),
+        qllc(68), fastEtherFX(69), channel(70), ieee80211(71),
+        ibm370parChan(72), escon(73), dlsw(74), isdns(75), isdnu(76),
+        lapd(77), ipSwitch(78), rsrb(79), atmLogical(80), ds0(81),
+        ds0Bundle(82), bsc(83), async(84), cnr(85), iso88025Dtr(86),
+        eplrs(87), arap(88), propCnls(89), hostPad(90), termPad(91),
+        frameRelayMPI(92), x213(93), adsl(94), radsl(95), sdsl(96),
+        vdsl(97), iso88025CRFPInt(98), myrinet(99), voiceEM(100),
+        voiceFXO(101), voiceFXS(102), voiceEncap(103), voiceOverIp(104),
+        atmDxi(105), atmFuni(106), atmIma(107), pppMultilinkBundle(108),
+        ipOverCdlc(109), ipOverClaw(110), stackToStack(111),
+        virtualIpAddress(112), mpc(113), ipOverAtm(114),
+        iso88025Fiber(115), tdlc(116), gigabitEthernet(117), hdlc(118),
+        lapf(119), v37(120), x25mlp(121), x25huntGroup(122),
+        transpHdlc(123), interleave(124), fast(125), ip(126),
+        docsCableMaclayer(127), docsCableDownstream(128),
+        docsCableUpstream(129), a12MppSwitch(130), tunnel(131),
+        coffee(132), ces(133), atmSubInterface(134), l2vlan(135),
+        l3ipvlan(136), l3ipxvlan(137), digitalPowerline(138),
+        mediaMailOverIp(139), dtm(140), dcn(141), ipForward(142),
+        msdsl(143), ieee1394(144), if-gsn(145), dvbRccMacLayer(146),
+        dvbRccDownstream(147), dvbRccUpstream(148), atmVirtual(149),
+        mplsTunnel(150), srp(151), voiceOverAtm(152),
+        voiceOverFrameRelay(153), idsl(154), compositeLink(155),
+        ss7SigLink(156), propWirelessP2P(157), frForward(158),
+        rfc1483(159), usb(160), ieee8023adLag(161),
+        bgppolicyaccounting(162), frf16MfrBundle(163),
+        h323Gatekeeper(164), h323Proxy(165), mpls(166), mfSigLink(167),
+        hdsl2(168), shdsl(169), ds1FDL(170), pos(171), dvbAsiIn(172),
+        dvbAsiOut(173), plc(174), nfas(175), tr008(176), gr303RDT(177),
+        gr303IDT(178), isup(179), propDocsWirelessMaclayer(180),
+        propDocsWirelessDownstream(181), propDocsWirelessUpstream(182),
+        hiperlan2(183), propBWAp2Mp(184), sonetOverheadChannel(185),
+        digitalWrapperOverheadChannel(186), aal2(187), radioMAC(188),
+        atmRadio(189), imt(190), mvl(191), reachDSL(192),
+        frDlciEndPt(193), atmVciEndPt(194), opticalChannel(195),
+        opticalTransport(196), propAtm(197), voiceOverCable(198),
+        infiniband(199), teLink(200), q2931(201), virtualTg(202),
+        sipTg(203), sipSig(204), docsCableUpstreamChannel(205),
+        econet(206), pon155(207), pon622(208), bridge(209),
+        linegroup(210), voiceEMFGD(211), voiceFGDEANA(212),
+        voiceDID(213), mpegTransport(214), sixToFour(215), gtp(216),
+        pdnEtherLoop1(217), pdnEtherLoop2(218), opticalChannelGroup(219),
+        homepna(220), gfp(221), ciscoISLvlan(222), actelisMetaLOOP(223),
+        fcipLink(224), rpr(225), qam(226), lmp(227), cblVectaStar(228),
+        docsCableMCmtsDownstream(229), adsl2(230),
+        macSecControlledIF(231), macSecUncontrolledIF(232),
+        aviciOpticalEther(233), atmbond(234), voiceFGDOS(235),
+        mocaVersion1(236), ieee80216WMAN(237), adsl2plus(238),
+        dvbRcsMacLayer(239), dvbTdm(240), dvbRcsTdma(241), x86Laps(242),
+        wwanPP(243), wwanPP2(244), voiceEBS(245), ifPwType(246),
+        ilan(247), pip(248), aluELP(249), gpon(250), vdsl2(251),
+        capwapDot11Profile(252), capwapDot11Bss(253),
+        capwapWtpVirtualRadio(254), bits(255),
+        docsCableUpstreamRfPort(256), cableDownstreamRfPort(257),
+        vmwareVirtualNic(258), ieee802154(259), otnOdu(260), otnOtu(261),
+        ifVfiType(262), g9981(263), g9982(264), g9983(265), aluEpon(266),
+        aluEponOnu(267), aluEponPhysicalUni(268), aluEponLogicalLink(269),
+        aluGponOnu(270), aluGponPhysicalUni(271), vmwareNicTeam(272),
+        docsOfdmDownstream(277), docsOfdmaUpstream(278), gfast(279),
+        sdci(280), usb2HighSpeedFibre(281), m4eSonet(282),
+        ieee8023adLagMbr(283), ieee8023adLagFibre(284),
+        ieee8023adLagLisonFibre(285), ieee8023adLagMod(286)
+    }
+
+END

--- a/backend/mibs_bundled/IP-MIB.txt
+++ b/backend/mibs_bundled/IP-MIB.txt
@@ -1,0 +1,214 @@
+IP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32, IpAddress,
+    mib-2
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, TruthValue
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+ipMIB MODULE-IDENTITY
+    LAST-UPDATED "200205090000Z"
+    ORGANIZATION "IETF IPv6 MIB Revision Team"
+    CONTACT-INFO "Editor: Mike Daniele"
+    DESCRIPTION  "The MIB module for managing IP and ICMP."
+    REVISION     "200205090000Z"
+    DESCRIPTION  "IP version of MIB updated."
+    ::= { mib-2 48 }
+
+ip OBJECT IDENTIFIER ::= { mib-2 4 }
+
+ipForwarding OBJECT-TYPE
+    SYNTAX     INTEGER { forwarding(1), notForwarding(2) }
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION "IP forwarding state."
+    ::= { ip 1 }
+
+ipDefaultTTL OBJECT-TYPE
+    SYNTAX     Integer32 (1..255)
+    MAX-ACCESS read-write
+    STATUS     current
+    DESCRIPTION "Default TTL in IP headers."
+    ::= { ip 2 }
+
+ipInReceives OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total input datagrams received."
+    ::= { ip 3 }
+
+ipInHdrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Input datagrams discarded due to header errors."
+    ::= { ip 4 }
+
+ipInAddrErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Input datagrams discarded due to address errors."
+    ::= { ip 5 }
+
+ipForwDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams forwarded."
+    ::= { ip 6 }
+
+ipInUnknownProtos OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams discarded due to unknown protocol."
+    ::= { ip 7 }
+
+ipInDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Input datagrams discarded due to resource issues."
+    ::= { ip 8 }
+
+ipInDelivers OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams delivered to IP user-protocols."
+    ::= { ip 9 }
+
+ipOutRequests OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams submitted for transmission."
+    ::= { ip 10 }
+
+ipOutDiscards OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Output datagrams discarded."
+    ::= { ip 11 }
+
+ipOutNoRoutes OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams discarded due to no route."
+    ::= { ip 12 }
+
+ipReasmTimeout OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Maximum seconds held while awaiting reassembly."
+    ::= { ip 13 }
+
+ipReasmReqds OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Received IP fragments needing reassembly."
+    ::= { ip 14 }
+
+ipReasmOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams successfully reassembled."
+    ::= { ip 15 }
+
+ipReasmFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Failures detected by IP reassembly algorithm."
+    ::= { ip 16 }
+
+ipFragOKs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams successfully fragmented."
+    ::= { ip 17 }
+
+ipFragFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams discarded because fragmentation failed."
+    ::= { ip 18 }
+
+ipFragCreates OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "IP datagram fragments generated."
+    ::= { ip 19 }
+
+ipAddrTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF IpAddrEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION "Table of IP address information."
+    ::= { ip 20 }
+
+IpAddrEntry ::= SEQUENCE {
+    ipAdEntAddr        IpAddress,
+    ipAdEntIfIndex     Integer32,
+    ipAdEntNetMask     IpAddress,
+    ipAdEntBcastAddr   Integer32,
+    ipAdEntReasmMaxSize Integer32
+}
+
+ipAddrEntry OBJECT-TYPE
+    SYNTAX     IpAddrEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION "IP address entry."
+    INDEX { ipAdEntAddr }
+    ::= { ipAddrTable 1 }
+
+ipAdEntAddr OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "IP address of this entry."
+    ::= { ipAddrEntry 1 }
+
+ipAdEntIfIndex OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "Interface index for this IP address."
+    ::= { ipAddrEntry 2 }
+
+ipAdEntNetMask OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "Subnet mask for this IP address."
+    ::= { ipAddrEntry 3 }
+
+ipAdEntBcastAddr OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "Broadcast address LSB value."
+    ::= { ipAddrEntry 4 }
+
+ipAdEntReasmMaxSize OBJECT-TYPE
+    SYNTAX     Integer32 (0..65535)
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "Largest datagram that can be reassembled."
+    ::= { ipAddrEntry 5 }
+
+END

--- a/backend/mibs_bundled/NOTIFICATION-LOG-MIB.txt
+++ b/backend/mibs_bundled/NOTIFICATION-LOG-MIB.txt
@@ -1,0 +1,99 @@
+NOTIFICATION-LOG-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32,
+    TimeTicks, mib-2
+        FROM SNMPv2-SMI
+    RowStatus, StorageType, DisplayString, DateAndTime,
+    TruthValue
+        FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF
+    SnmpAdminString
+        FROM SNMP-FRAMEWORK-MIB;
+
+notificationLogMIB MODULE-IDENTITY
+    LAST-UPDATED "200011270000Z"
+    ORGANIZATION "IETF Distributed Management Working Group"
+    CONTACT-INFO "IETF Distributed Management Working Group"
+    DESCRIPTION  "The MIB module for logging SNMP Notifications."
+    REVISION     "200011270000Z"
+    DESCRIPTION  "Initial version, RFC 3014."
+    ::= { mib-2 92 }
+
+nlmMIBObjects   OBJECT IDENTIFIER ::= { notificationLogMIB 1 }
+nlmConfig       OBJECT IDENTIFIER ::= { nlmMIBObjects 1 }
+nlmStats        OBJECT IDENTIFIER ::= { nlmMIBObjects 2 }
+nlmLog          OBJECT IDENTIFIER ::= { nlmMIBObjects 3 }
+
+nlmConfigGlobalEntryLimit OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Global max number of notification log entries."
+    DEFVAL { 0 }
+    ::= { nlmConfig 1 }
+
+nlmConfigGlobalAgeOut OBJECT-TYPE
+    SYNTAX      Unsigned32
+    UNITS       "minutes"
+    MAX-ACCESS  read-write
+    STATUS      current
+    DESCRIPTION "Minutes before an entry is aged out (0=never)."
+    DEFVAL { 1440 }
+    ::= { nlmConfig 2 }
+
+nlmStatsGlobalNotificationsLogged OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Total notifications that have been logged."
+    ::= { nlmStats 1 }
+
+nlmStatsGlobalNotificationsBumped OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Notifications dropped due to log size limit."
+    ::= { nlmStats 2 }
+
+nlmLogTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF NlmLogEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "Table of logged notifications."
+    ::= { nlmLog 1 }
+
+NlmLogEntry ::= SEQUENCE {
+    nlmLogIndex         Unsigned32,
+    nlmLogTime          TimeTicks,
+    nlmLogDateAndTime   DateAndTime,
+    nlmLogEngineID      OCTET STRING,
+    nlmLogEngineTAddress OCTET STRING,
+    nlmLogContextName   SnmpAdminString,
+    nlmLogNotificationID OBJECT IDENTIFIER
+}
+
+nlmLogEntry OBJECT-TYPE
+    SYNTAX      NlmLogEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "A log entry for a notification."
+    INDEX { nlmLogName, nlmLogIndex }
+    ::= { nlmLogTable 1 }
+
+nlmLogTime OBJECT-TYPE
+    SYNTAX      TimeTicks
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "sysUpTime when notification was logged."
+    ::= { nlmLogEntry 2 }
+
+nlmLogNotificationID OBJECT-TYPE
+    SYNTAX      OBJECT IDENTIFIER
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "OID of the notification."
+    ::= { nlmLogEntry 7 }
+
+END

--- a/backend/mibs_bundled/SNMPv2-CONF.txt
+++ b/backend/mibs_bundled/SNMPv2-CONF.txt
@@ -1,0 +1,222 @@
+SNMPv2-CONF DEFINITIONS ::= BEGIN
+
+OBJECT-GROUP MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  ObjectsPart
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+    ObjectsPart ::=
+                  "OBJECTS" "{" Objects "}"
+    Objects ::=
+                  Object
+                | Objects "," Object
+    Object ::=
+                  value(ObjectName)
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+    Text ::= value(IA5String)
+END
+
+NOTIFICATION-GROUP MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  NotificationsPart
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+    NotificationsPart ::=
+                  "NOTIFICATIONS" "{" Notifications "}"
+    Notifications ::=
+                  Notification
+                | Notifications "," Notification
+    Notification ::=
+                  value(NotificationName)
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+    Text ::= value(IA5String)
+END
+
+MODULE-COMPLIANCE MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+                  ModulePart
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+    ModulePart ::=
+                  Modules
+    Modules ::=
+                  Module
+                | Modules Module
+    Module ::=
+                  "MODULE" RefinedModule
+    RefinedModule ::=
+                  ModuleName
+                  MandatoryPart
+                  CompliancePart
+    ModuleName ::=
+                  identifier ModuleIdentifier
+    ModuleIdentifier ::=
+                  value(OBJECT IDENTIFIER)
+                | empty
+    MandatoryPart ::=
+                  "MANDATORY-GROUPS" "{" Groups "}"
+                | empty
+    Groups ::=
+                  Group
+                | Groups "," Group
+    Group ::=
+                  value(OBJECT IDENTIFIER)
+    CompliancePart ::=
+                  Compliances
+                | empty
+    Compliances ::=
+                  Compliance
+                | Compliances Compliance
+    Compliance ::=
+                  ComplianceGroup
+                | Object
+    ComplianceGroup ::=
+                  "GROUP" value(OBJECT IDENTIFIER)
+                  "DESCRIPTION" Text
+    Object ::=
+                  "OBJECT" value(ObjectName)
+                  SyntaxPart
+                  WriteSyntaxPart
+                  AccessPart
+                  "DESCRIPTION" Text
+    SyntaxPart ::= "SYNTAX" Syntax
+                | empty
+    WriteSyntaxPart ::= "WRITE-SYNTAX" Syntax
+                | empty
+    Syntax ::=   type
+                 | "BITS" "{" NamedBits "}"
+    NamedBits ::= NamedBit
+                | NamedBits "," NamedBit
+    NamedBit ::=  identifier "(" number ")"
+    AccessPart ::=
+                  "MIN-ACCESS" Access
+                | empty
+    Access ::=
+                  "not-accessible"
+                | "accessible-for-notify"
+                | "read-only"
+                | "read-write"
+                | "read-create"
+    Text ::= value(IA5String)
+END
+
+AGENT-CAPABILITIES MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "PRODUCT-RELEASE" Text
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+                  ModulePart
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+    Status ::=
+                  "current"
+                | "obsolete"
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+    ModulePart ::=
+                  Modules
+    Modules ::=
+                  Module
+                | Modules Module
+    Module ::=
+                  "SUPPORTS" ModuleName
+                  "INCLUDES" "{" Groups "}"
+                  VariationPart
+    ModuleName ::=
+                  identifier ModuleIdentifier
+    ModuleIdentifier ::=
+                  value(OBJECT IDENTIFIER)
+                | empty
+    Groups ::=
+                  Group
+                | Groups "," Group
+    Group ::=
+                  value(OBJECT IDENTIFIER)
+    VariationPart ::=
+                  Variations
+                | empty
+    Variations ::=
+                  Variation
+                | Variations Variation
+    Variation ::=
+                  ObjectVariation
+                | NotificationVariation
+    NotificationVariation ::=
+                  "VARIATION" value(NotificationName)
+                  AccessPart
+                  "DESCRIPTION" Text
+    ObjectVariation ::=
+                  "VARIATION" value(ObjectName)
+                  SyntaxPart
+                  WriteSyntaxPart
+                  AccessPart
+                  CreationPart
+                  DefValPart
+                  "DESCRIPTION" Text
+    SyntaxPart ::= "SYNTAX" Syntax
+                | empty
+    WriteSyntaxPart ::= "WRITE-SYNTAX" Syntax
+                | empty
+    Syntax ::=   type
+                 | "BITS" "{" NamedBits "}"
+    NamedBits ::= NamedBit
+                | NamedBits "," NamedBit
+    NamedBit ::=  identifier "(" number ")"
+    AccessPart ::=
+                  "ACCESS" Access
+                | empty
+    Access ::=
+                  "not-implemented"
+                | "accessible-for-notify"
+                | "read-only"
+                | "read-write"
+                | "read-create"
+                | "write-only"
+    CreationPart ::=
+                  "CREATION-REQUIRES" "{" Cells "}"
+                | empty
+    Cells ::=
+                  Cell
+                | Cells "," Cell
+    Cell ::=
+                  value(ObjectName)
+    DefValPart ::= "DEFVAL" "{" value(Defval ObjectSyntax) "}"
+                | empty
+    Text ::= value(IA5String)
+END
+
+END

--- a/backend/mibs_bundled/SNMPv2-SMI.txt
+++ b/backend/mibs_bundled/SNMPv2-SMI.txt
@@ -1,0 +1,263 @@
+SNMPv2-SMI DEFINITIONS ::= BEGIN
+
+--  the path to the root
+
+org            OBJECT IDENTIFIER ::= { iso 3 }  --  "iso" = 1
+dod            OBJECT IDENTIFIER ::= { org 6 }
+internet       OBJECT IDENTIFIER ::= { dod 1 }
+
+directory      OBJECT IDENTIFIER ::= { internet 1 }
+
+mgmt           OBJECT IDENTIFIER ::= { internet 2 }
+mib-2          OBJECT IDENTIFIER ::= { mgmt 1 }
+transmission   OBJECT IDENTIFIER ::= { mib-2 10 }
+
+experimental   OBJECT IDENTIFIER ::= { internet 3 }
+
+private        OBJECT IDENTIFIER ::= { internet 4 }
+enterprises    OBJECT IDENTIFIER ::= { private 1 }
+
+security       OBJECT IDENTIFIER ::= { internet 5 }
+
+snmpV2         OBJECT IDENTIFIER ::= { internet 6 }
+
+--  transport domains
+snmpDomains    OBJECT IDENTIFIER ::= { snmpV2 1 }
+
+--  transport proxies
+snmpProxys     OBJECT IDENTIFIER ::= { snmpV2 2 }
+
+--  module identities
+snmpModules    OBJECT IDENTIFIER ::= { snmpV2 3 }
+
+-- definitions for information modules
+
+MODULE-IDENTITY MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "LAST-UPDATED" value(Update UTCTime)
+                  "ORGANIZATION" Text
+                  "CONTACT-INFO" Text
+                  "DESCRIPTION" Text
+                  RevisionPart
+
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+
+    RevisionPart ::=
+                  Revisions
+                | empty
+    Revisions ::=
+                  Revision
+                | Revisions Revision
+    Revision ::=
+                  "REVISION" value(Update UTCTime)
+                  "DESCRIPTION" Text
+
+                -- a character string as defined in section 3.1.1
+    Text ::= value(IA5String)
+END
+
+OBJECT-IDENTITY MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+
+    VALUE NOTATION ::=
+                  value(VALUE OBJECT IDENTIFIER)
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    Text ::= value(IA5String)
+END
+
+-- names of objects
+
+ObjectName ::=
+    OBJECT IDENTIFIER
+
+NotificationName ::=
+    OBJECT IDENTIFIER
+
+-- syntax of objects
+
+ObjectSyntax ::=
+    CHOICE {
+        simple
+            SimpleSyntax,
+          -- note that SEQUENCEs for conceptual tables and
+          -- rows are not mentioned here...
+        application-wide
+            ApplicationSyntax
+    }
+
+-- built-in ASN.1 types
+
+SimpleSyntax ::=
+    CHOICE {
+        integer-value
+            INTEGER (-2147483648..2147483647),
+        string-value
+            OCTET STRING (SIZE (0..65535)),
+        objectID-value
+            OBJECT IDENTIFIER
+    }
+
+Integer32 ::=
+        INTEGER (-2147483648..2147483647)
+
+ApplicationSyntax ::=
+    CHOICE {
+        ipAddress-value
+            IpAddress,
+        counter-value
+            Counter32,
+        timeticks-value
+            TimeTicks,
+        arbitrary-value
+            Opaque,
+        big-counter-value
+            Counter64,
+        unsigned-integer-value
+            Unsigned32
+    }
+
+IpAddress ::=
+    [APPLICATION 0]
+        IMPLICIT OCTET STRING (SIZE (4))
+
+Counter32 ::=
+    [APPLICATION 1]
+        IMPLICIT INTEGER (0..4294967295)
+
+Gauge32 ::=
+    [APPLICATION 2]
+        IMPLICIT INTEGER (0..4294967295)
+
+Unsigned32 ::=
+    [APPLICATION 2]
+        IMPLICIT INTEGER (0..4294967295)
+
+TimeTicks ::=
+    [APPLICATION 3]
+        IMPLICIT INTEGER (0..4294967295)
+
+Opaque ::=
+    [APPLICATION 4]
+        IMPLICIT OCTET STRING
+
+Counter64 ::=
+    [APPLICATION 6]
+        IMPLICIT INTEGER (0..18446744073709551615)
+
+OBJECT-TYPE MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  "SYNTAX" Syntax
+                  UnitsPart
+                  "MAX-ACCESS" Access
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+                  IndexPart
+                  MibIndex
+                  DefValPart
+
+    VALUE NOTATION ::=
+                  value(VALUE ObjectName)
+
+    Syntax ::=   type
+                 | "BITS" "{" NamedBits "}"
+
+    NamedBits ::= NamedBit
+                | NamedBits "," NamedBit
+
+    NamedBit ::=  identifier "(" number ")"
+
+    UnitsPart ::=
+                  "UNITS" Text
+                | empty
+
+    Access ::=
+                  "not-accessible"
+                | "accessible-for-notify"
+                | "read-only"
+                | "read-write"
+                | "read-create"
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    IndexPart ::=
+                  "INDEX"    "{" IndexTypes "}"
+                | "AUGMENTS" "{" Entry      "}"
+                | empty
+    IndexTypes ::=
+                  IndexType
+                | IndexTypes "," IndexType
+    IndexType ::=
+                  "IMPLIED" Index
+                | Index
+
+    MibIndex ::=
+                  empty
+
+    Index ::=
+                  value(ObjectName)
+    Entry ::=
+                  value(ObjectName)
+
+    DefValPart ::= "DEFVAL" "{" value(Defval ObjectSyntax) "}"
+                | empty
+
+    Text ::= value(IA5String)
+END
+
+NOTIFICATION-TYPE MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  ObjectsPart
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+
+    VALUE NOTATION ::=
+                  value(VALUE NotificationName)
+
+    ObjectsPart ::=
+                  "OBJECTS" "{" Objects "}"
+                | empty
+    Objects ::=
+                  Object
+                | Objects "," Object
+    Object ::=
+                  value(ObjectName)
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    Text ::= value(IA5String)
+END
+
+END

--- a/backend/mibs_bundled/SNMPv2-TC.txt
+++ b/backend/mibs_bundled/SNMPv2-TC.txt
@@ -1,0 +1,136 @@
+SNMPv2-TC DEFINITIONS ::= BEGIN
+
+IMPORTS
+    INTEGER, OCTET STRING, OBJECT IDENTIFIER
+        FROM SNMPv2-SMI;
+
+TEXTUAL-CONVENTION MACRO ::=
+BEGIN
+    TYPE NOTATION ::=
+                  DisplayPart
+                  "STATUS" Status
+                  "DESCRIPTION" Text
+                  ReferPart
+                  "SYNTAX" Syntax
+
+    VALUE NOTATION ::=
+                  value(VALUE Syntax)
+
+    DisplayPart ::=
+                  "DISPLAY-HINT" Text
+                | empty
+
+    Status ::=
+                  "current"
+                | "deprecated"
+                | "obsolete"
+
+    ReferPart ::=
+                  "REFERENCE" Text
+                | empty
+
+    Text ::= value(IA5String)
+
+    Syntax ::=   type
+                 | "BITS" "{" NamedBits "}"
+
+    NamedBits ::= NamedBit
+                | NamedBits "," NamedBit
+
+    NamedBit ::=  identifier "(" number ")"
+END
+
+DisplayString ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "255a"
+    STATUS       current
+    DESCRIPTION  "NVT ASCII string, max 255 chars."
+    SYNTAX       OCTET STRING (SIZE (0..255))
+
+PhysAddress ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1x:"
+    STATUS       current
+    DESCRIPTION  "Media/physical address."
+    SYNTAX       OCTET STRING
+
+MacAddress ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "1x:"
+    STATUS       current
+    DESCRIPTION  "802 MAC address in canonical order."
+    SYNTAX       OCTET STRING (SIZE (6))
+
+TruthValue ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Boolean value."
+    SYNTAX       INTEGER { true(1), false(2) }
+
+TestAndIncr ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Atomic integer for test-and-increment operations."
+    SYNTAX       INTEGER (0..2147483647)
+
+AutonomousType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Independently extensible type identification."
+    SYNTAX       OBJECT IDENTIFIER
+
+VariablePointer ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Pointer to a specific object instance."
+    SYNTAX       OBJECT IDENTIFIER
+
+RowPointer ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Pointer to a conceptual row."
+    SYNTAX       OBJECT IDENTIFIER
+
+RowStatus ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Used to manage creation and deletion of conceptual rows."
+    SYNTAX   INTEGER {
+                 active(1),
+                 notInService(2),
+                 notReady(3),
+                 createAndGo(4),
+                 createAndWait(5),
+                 destroy(6)
+             }
+
+TimeStamp ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Value of sysUpTime at which a specific occurrence happened."
+    SYNTAX       TimeTicks
+
+TimeInterval ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "d"
+    STATUS       current
+    DESCRIPTION  "Period of time in units of 0.01 seconds."
+    SYNTAX       INTEGER (0..2147483647)
+
+DateAndTime ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT "2d-1d-1d,1d:1d:1d.1d,1a1d:1d"
+    STATUS       current
+    DESCRIPTION  "A date-time specification."
+    SYNTAX       OCTET STRING (SIZE (8 | 11))
+
+StorageType ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Memory realization of a conceptual row."
+    SYNTAX   INTEGER {
+                 other(1),
+                 volatile(2),
+                 nonVolatile(3),
+                 permanent(4),
+                 readOnly(5)
+             }
+
+TDomain ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Denotes a kind of transport service."
+    SYNTAX       OBJECT IDENTIFIER
+
+TAddress ::= TEXTUAL-CONVENTION
+    STATUS       current
+    DESCRIPTION  "Denotes a transport service address."
+    SYNTAX       OCTET STRING (SIZE (1..255))
+
+END

--- a/backend/mibs_bundled/TCP-MIB.txt
+++ b/backend/mibs_bundled/TCP-MIB.txt
@@ -1,0 +1,119 @@
+TCP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32, Counter32, IpAddress,
+    mib-2
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+tcpMIB MODULE-IDENTITY
+    LAST-UPDATED "200205090000Z"
+    ORGANIZATION "IETF"
+    CONTACT-INFO "IETF SNMPv2 Working Group"
+    DESCRIPTION  "The MIB module for managing TCP implementations."
+    REVISION     "200205090000Z"
+    DESCRIPTION  "Initial version."
+    ::= { mib-2 49 }
+
+tcp OBJECT IDENTIFIER ::= { mib-2 6 }
+
+tcpRtoAlgorithm OBJECT-TYPE
+    SYNTAX     INTEGER { other(1), constant(2), rsre(3), vanj(4), rfc2988(5) }
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Algorithm used to determine retransmission timeout."
+    ::= { tcp 1 }
+
+tcpRtoMin OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Minimum retransmission timeout in milliseconds."
+    ::= { tcp 2 }
+
+tcpRtoMax OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Maximum retransmission timeout in milliseconds."
+    ::= { tcp 3 }
+
+tcpMaxConn OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Limit on total TCP connections the entity can support."
+    ::= { tcp 4 }
+
+tcpActiveOpens OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of times TCP connections made active open transition."
+    ::= { tcp 5 }
+
+tcpPassiveOpens OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of times TCP connections made passive open transition."
+    ::= { tcp 6 }
+
+tcpAttemptFails OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of failed TCP connection attempts."
+    ::= { tcp 7 }
+
+tcpEstabResets OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of resets from ESTABLISHED or CLOSE-WAIT state."
+    ::= { tcp 8 }
+
+tcpCurrEstab OBJECT-TYPE
+    SYNTAX     Integer32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Number of TCP connections currently ESTABLISHED or CLOSE-WAIT."
+    ::= { tcp 9 }
+
+tcpInSegs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total segments received."
+    ::= { tcp 10 }
+
+tcpOutSegs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total segments sent."
+    ::= { tcp 11 }
+
+tcpRetransSegs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total segments retransmitted."
+    ::= { tcp 12 }
+
+tcpInErrs OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Segments received with errors."
+    ::= { tcp 14 }
+
+tcpOutRsts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Segments sent with RST flag."
+    ::= { tcp 15 }
+
+END

--- a/backend/mibs_bundled/UDP-MIB.txt
+++ b/backend/mibs_bundled/UDP-MIB.txt
@@ -1,0 +1,83 @@
+UDP-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Counter32, Integer32, IpAddress,
+    mib-2
+        FROM SNMPv2-SMI
+    MODULE-COMPLIANCE, OBJECT-GROUP
+        FROM SNMPv2-CONF;
+
+udpMIB MODULE-IDENTITY
+    LAST-UPDATED "200205090000Z"
+    ORGANIZATION "IETF"
+    CONTACT-INFO "IETF SNMPv2 Working Group"
+    DESCRIPTION  "The MIB module for managing UDP implementations."
+    REVISION     "200205090000Z"
+    DESCRIPTION  "Initial version."
+    ::= { mib-2 50 }
+
+udp OBJECT IDENTIFIER ::= { mib-2 7 }
+
+udpInDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total UDP datagrams delivered to users."
+    ::= { udp 1 }
+
+udpNoPorts OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams for which no app was at destination port."
+    ::= { udp 2 }
+
+udpInErrors OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Datagrams unable to be delivered for other reasons."
+    ::= { udp 3 }
+
+udpOutDatagrams OBJECT-TYPE
+    SYNTAX     Counter32
+    MAX-ACCESS read-only
+    STATUS     current
+    DESCRIPTION "Total UDP datagrams sent."
+    ::= { udp 4 }
+
+udpTable OBJECT-TYPE
+    SYNTAX     SEQUENCE OF UdpEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION "Table of UDP listener information."
+    ::= { udp 5 }
+
+UdpEntry ::= SEQUENCE {
+    udpLocalAddress IpAddress,
+    udpLocalPort    Integer32
+}
+
+udpEntry OBJECT-TYPE
+    SYNTAX     UdpEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION "UDP listener entry."
+    INDEX { udpLocalAddress, udpLocalPort }
+    ::= { udpTable 1 }
+
+udpLocalAddress OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "Local IP address for this UDP listener."
+    ::= { udpEntry 1 }
+
+udpLocalPort OBJECT-TYPE
+    SYNTAX     Integer32 (0..65535)
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION "Local port for this UDP listener."
+    ::= { udpEntry 2 }
+
+END


### PR DESCRIPTION
…erfile

- Removes snmp-mibs-downloader apt package (~50MB saved)
- Removes RUN download-mibs step (eliminated 200+ file network download at build time)
- Faster, reproducible, offline-capable builds
- Added MIBs: SNMPv2-SMI, SNMPv2-TC, SNMPv2-CONF, IANAifType-MIB, IP-MIB, TCP-MIB, UDP-MIB, HOST-RESOURCES-MIB, BRIDGE-MIB, DISMAN-EVENT-MIB, NOTIFICATION-LOG-MIB, ENTITY-MIB (IF-MIB, RFC1213-MIB, RMON-MIB, SNMPv2-MIB were already bundled)