### PR TITLE
fix(#26): sync resolve toggle checkbox from backend status on page load

### DIFF
--- a/frontend/src/js/modules/traps.js
+++ b/frontend/src/js/modules/traps.js
@@ -530,11 +530,12 @@ window.TrapsModule = {
     },
 
     updateStatusUI: function(status) {
-        const badge        = document.getElementById("tr-status-badge");
-        const detail       = document.getElementById("tr-status-detail");
-        const btnStart     = document.getElementById("btn-tr-start");
-        const btnStop      = document.getElementById("btn-tr-stop");
-        const metricsPanel = document.getElementById("tr-metrics");
+        const badge         = document.getElementById("tr-status-badge");
+        const detail        = document.getElementById("tr-status-detail");
+        const btnStart      = document.getElementById("btn-tr-start");
+        const btnStop       = document.getElementById("btn-tr-stop");
+        const metricsPanel  = document.getElementById("tr-metrics");
+        const resolveToggle = document.getElementById("tr-resolve-toggle");
         
         if (!badge) return;
         
@@ -543,6 +544,11 @@ window.TrapsModule = {
             badge.textContent = "RUNNING";
             if (detail) {
                 detail.textContent = `Port ${status.port || '--'} | ${status.resolve_mibs ? 'Resolved' : 'Raw'}`;
+            }
+            // Fix #26: sync the resolve toggle checkbox to the actual running state
+            // so that any user opening the page sees the correct value, not the HTML default.
+            if (resolveToggle && status.resolve_mibs != null) {
+                resolveToggle.checked = status.resolve_mibs;
             }
             // Cache uptime_seconds for updateMetrics()
             this._receiverUptime = status.uptime_seconds != null ? status.uptime_seconds : null;
@@ -553,6 +559,11 @@ window.TrapsModule = {
             badge.className   = "badge bg-secondary";
             badge.textContent = "STOPPED";
             if (detail) detail.textContent = "";
+            // Fix #26: also sync toggle when stopped, using last known resolve_mibs
+            // value returned by the backend (resolve_mibs is non-null even when stopped).
+            if (resolveToggle && status.resolve_mibs != null) {
+                resolveToggle.checked = status.resolve_mibs;
+            }
             this._receiverUptime = null;
             if (metricsPanel) metricsPanel.classList.add('d-none');
             btnStart.disabled = false;


### PR DESCRIPTION
## Problem (Fixes #26)

When User1 disables the **Resolve MIBs** toggle, stops, and restarts the trap receiver, User2 opening the page sees the toggle as **ON** (enabled) — even though the receiver is actually running with `resolve_mibs=false`.

### Root Cause

`updateStatusUI()` in `traps.js` received the correct `resolve_mibs` value from `/api/traps/status` and used it to update the **status detail text** (`Resolved / Raw`), but **never wrote it back to the `tr-resolve-toggle` checkbox**.

The checkbox always rendered from its HTML default (`checked`), so any fresh session/login would show the toggle as ON regardless of actual backend state.

### Fix

Added two lines inside `updateStatusUI()` to sync `tr-resolve-toggle.checked` from `status.resolve_mibs` — both when the receiver is **running** and **stopped**:

```js
// Fix #26: sync the resolve toggle checkbox to the actual backend state
if (resolveToggle && status.resolve_mibs != null) {
    resolveToggle.checked = status.resolve_mibs;
}
```

This is applied in both the `running` and `stopped` branches so the toggle is always consistent with what the backend reports, for every user and every session.

### Files Changed
- `frontend/src/js/modules/traps.js` — `updateStatusUI()` function only